### PR TITLE
feat: Add GitHub Action to build and release APK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Build and Release APK
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
+    - name: Download apktool
+      run: |
+        wget https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.9.3.jar -O apktool.jar
+        sudo mv apktool.jar /usr/local/bin/apktool.jar
+        sudo ln -s /usr/local/bin/apktool.jar /usr/local/bin/apktool
+        sudo chmod +x /usr/local/bin/apktool.jar
+        sudo chmod +x /usr/local/bin/apktool
+
+    - name: Decode Keystore
+      run: |
+        echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > keystore.jks
+
+    - name: Build APK
+      run: |
+        apktool b decompiled_full -o unsigned.apk
+
+    - name: Sign APK
+      run: |
+        apksigner sign --ks keystore.jks \
+          --ks-key-alias ${{ secrets.KEY_ALIAS }} \
+          --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
+          --key-pass pass:${{ secrets.KEY_PASSWORD }} \
+          unsigned.apk
+
+        mv unsigned.apk signed.apk
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v1.0.${{ github.run_number }}
+        release_name: Release v1.0.${{ github.run_number }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./signed.apk
+        asset_name: FBD-VPN-PRO.apk
+        asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the process of building, signing, and releasing the Android application.

The workflow (`.github/workflows/release.yml`) is manually triggerable and performs the following actions:
- Sets up a Java environment.
- Downloads and installs apktool.
- Recompiles the application from the `decompiled_full` directory.
- Signs the generated APK using a keystore and credentials stored in GitHub Secrets.
- Creates a GitHub Release and uploads the signed APK as an asset.