### PR TITLE
fix: Correct apktool execution in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,6 @@ jobs:
     - name: Download apktool
       run: |
         wget https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.9.3.jar -O apktool.jar
-        sudo mv apktool.jar /usr/local/bin/apktool.jar
-        sudo ln -s /usr/local/bin/apktool.jar /usr/local/bin/apktool
-        sudo chmod +x /usr/local/bin/apktool.jar
-        sudo chmod +x /usr/local/bin/apktool
 
     - name: Decode Keystore
       run: |
@@ -31,7 +27,7 @@ jobs:
 
     - name: Build APK
       run: |
-        apktool b decompiled_full -o unsigned.apk
+        java -jar apktool.jar b decompiled_full -o unsigned.apk
 
     - name: Sign APK
       run: |


### PR DESCRIPTION
This commit fixes an error in the GitHub Actions release workflow. The previous method of executing `apktool` by moving it to `/usr/local/bin` was incorrect and caused the build to fail.

The workflow has been updated to execute `apktool` directly using `java -jar apktool.jar`, which is the correct and recommended way to run the tool.