### PR TITLE
fix: Add Android build-tools to PATH in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       run: |
         java -jar apktool.jar b decompiled_output -o unsigned.apk
 
+    - name: Add apksigner to PATH
+      run: echo "$ANDROID_SDK_ROOT/build-tools/$(ls $ANDROID_SDK_ROOT/build-tools | sort -r | head -n 1)" >> $GITHUB_PATH
+
     - name: Sign APK
       run: |
         apksigner sign --ks keystore.jks \


### PR DESCRIPTION
This commit resolves a "command not found" error for `apksigner` during the signing step of the release workflow.

Although the Android SDK is available on the runner, the directory containing the build tools (like `apksigner`) is not always in the default PATH. This change adds a new step that dynamically locates the latest installed build-tools version and adds its directory to the `GITHUB_PATH`.

This ensures that `apksigner` is available for the signing step, completing the chain of fixes required to make the decompile, recompile, and release process fully functional.