### PR TITLE
fix: Use --out flag in apksigner for robust signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
 
     - name: Sign APK
       run: |
-        apksigner sign --ks keystore.jks \
+        apksigner sign \
+          --ks keystore.jks \
           --ks-key-alias ${{ secrets.KEY_ALIAS }} \
           --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
           --key-pass pass:${{ secrets.KEY_PASSWORD }} \
+          --out signed.apk \
           unsigned.apk
-
-        mv unsigned.apk signed.apk
 
     - name: Create Release
       id: create_release


### PR DESCRIPTION
This commit resolves an `Unexpected parameter(s)` error from `apksigner`. The previous command syntax was causing parsing issues with the runner's version of the tool.

The `apksigner` command has been updated to use the `--out` flag to explicitly specify the output file. This is a more robust and recommended syntax that avoids ambiguity in argument parsing. This change also simplifies the workflow by removing the subsequent `mv` command.

This should be the final fix to make the release workflow fully operational.