### PR TITLE
fix: Restore decompile step and finalize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,13 @@ jobs:
       run: |
         echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > keystore.jks
 
+    - name: Decompile APK
+      run: |
+        java -jar apktool.jar d FBD_VPN_PROcom.fbd.tunnelv404.apk -o decompiled_output -f
+
     - name: Build APK
       run: |
-        java -jar apktool.jar b decompiled_full -o unsigned.apk
+        java -jar apktool.jar b decompiled_output -o unsigned.apk
 
     - name: Add apksigner to PATH
       run: echo "$ANDROID_SDK_ROOT/build-tools/$(ls $ANDROID_SDK_ROOT/build-tools | sort -r | head -n 1)" >> $GITHUB_PATH


### PR DESCRIPTION
This commit reverts the build logic to the robust decompile-then-recompile model, which is necessary to resolve the `apktool.yml not found` error. This change was re-approved by the user after confirming that building from the existing `decompiled_full` directory is not feasible.

This final version incorporates all cumulative fixes:
1.  **Build Logic:** Decompiles the source APK at runtime to ensure a valid project structure for recompilation.
2.  **`apksigner` Path:** Adds the Android build-tools directory to the runner's PATH to find the `apksigner` executable.
3.  **`apksigner` Command:** Uses a simplified and robust signing command (without `--key-pass`) to prevent argument parsing errors.

This should complete the task and result in a fully functional release workflow.