### PR TITLE
feat: Automate and improve GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: Recompile, Sign, and Release APK
 
 on:
   workflow_dispatch:
-    inputs:
-      app_name:
-        description: 'The name of the app to build from the decompiled directory'
-        required: true
 
 jobs:
   build_and_release:
@@ -35,10 +31,22 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > release.keystore
 
+      - name: Find App Name
+        id: find_app
+        run: |
+          APP_DIR=$(find decompiled -mindepth 1 -maxdepth 1 -type d | head -n 1)
+          if [ -z "$APP_DIR" ]; then
+            echo "❌ No app directory found under 'decompiled/'"
+            exit 1
+          fi
+          APP_NAME=$(basename "$APP_DIR")
+          echo "✅ Found app: $APP_NAME"
+          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+
       - name: Recompile APK
         id: recompile
         run: |
-          APP_NAME="${{ github.event.inputs.app_name }}"
+          APP_NAME="${{ steps.find_app.outputs.app_name }}"
           SOURCE_DIR="decompiled/${APP_NAME}/apktool"
           UNSIGNED_APK="rebuilt_unsigned.apk"
 
@@ -69,7 +77,8 @@ jobs:
       - name: Zipalign APK
         id: zipalign
         run: |
-          FINAL_APK="${{ github.event.inputs.app_name }}_release.apk"
+          APP_NAME="${{ steps.find_app.outputs.app_name }}"
+          FINAL_APK="${APP_NAME}_release.apk"
           echo "📦 Aligning APK..."
           zipalign -f 4 "${{ steps.sign.outputs.signed_apk_path }}" "$FINAL_APK"
           echo "✅ Zipalign complete: $FINAL_APK"
@@ -78,12 +87,12 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: release-${{ github.event.inputs.app_name }}-${{ github.run_number }}
-          name: "Release ${{ github.event.inputs.app_name }} #${{ github.run_number }}"
+          tag_name: release-${{ steps.find_app.outputs.app_name }}-${{ github.run_number }}
+          name: "Release ${{ steps.find_app.outputs.app_name }} #${{ github.run_number }}"
           body: |
-            🚀 **${{ github.event.inputs.app_name }}**
+            🚀 **${{ steps.find_app.outputs.app_name }}**
 
-            - Recompiled from `decompiled/${{ github.event.inputs.app_name }}/apktool`
+            - Recompiled from `decompiled/${{ steps.find_app.outputs.app_name }}/apktool`
             - Signed with release key.
             - Workflow run: ${{ github.run_id }}
           files: "${{ steps.zipalign.outputs.final_apk_path }}"


### PR DESCRIPTION
This commit enhances the GitHub Actions workflow for recompiling, signing, and releasing APKs.

The workflow now:
- Automatically detects the application directory within the `decompiled` folder, removing the need for manual input.
- Is triggered manually via `workflow_dispatch`.
- Uses `apksigner` and `zipalign` for a more modern and secure signing process.
- Relies on GitHub secrets for the keystore and passwords.
- Creates a GitHub Release with the final APK as an artifact.