### PR TITLE
feat: Configure release workflow for test signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Recompile, Sign, and Release APK
+name: Recompile, Sign, and Release APK (Test Build)
 
 on:
   workflow_dispatch:
@@ -23,19 +23,6 @@ jobs:
         run: |
           wget -q https://github.com/iBotPeaches/Apktool/releases/download/v2.9.3/apktool_2.9.3.jar -O apktool.jar
           wget -q https://github.com/patrickfav/uber-apk-signer/releases/download/v1.3.0/uber-apk-signer-1.3.0.jar -O uber-apk-signer.jar
-
-      - name: Decode Original Keystore
-        run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > release.p12
-
-      - name: Convert Keystore to JKS
-        run: |
-          keytool -importkeystore \
-            -srckeystore release.p12 -srcstoretype PKCS12 -srcstorepass "${{ secrets.KEYSTORE_PASSWORD }}" \
-            -destkeystore release.jks -deststoretype JKS -deststorepass "${{ secrets.KEYSTORE_PASSWORD }}" \
-            -destkeypass "${{ secrets.KEY_PASSWORD }}" -srcalias "${{ secrets.KEY_ALIAS }}" \
-            -destalias "${{ secrets.KEY_ALIAS }}" -noprompt
-          echo "✅ Keystore converted to JKS format."
 
       - name: Find App Name
         id: find_app
@@ -66,18 +53,14 @@ jobs:
           echo "✅ Recompile complete: $UNSIGNED_APK"
           echo "unsigned_apk_path=$UNSIGNED_APK" >> $GITHUB_OUTPUT
 
-      - name: Sign and Align with uber-apk-signer
+      - name: Sign and Align with Debug Key
         id: sign
         run: |
           APP_NAME="${{ steps.find_app.outputs.app_name }}"
-          FINAL_APK="${APP_NAME}_release.apk"
-          echo "🔑 Signing and aligning with uber-apk-signer using JKS keystore..."
+          FINAL_APK="${APP_NAME}_debug_release.apk"
+          echo "🔑 Signing and aligning with uber-apk-signer's debug key..."
           java -jar uber-apk-signer.jar \
             --apks "${{ steps.recompile.outputs.unsigned_apk_path }}" \
-            --ks release.jks \
-            --ksPass "${{ secrets.KEYSTORE_PASSWORD }}" \
-            --ksAlias "${{ secrets.KEY_ALIAS }}" \
-            --keyPass "${{ secrets.KEY_PASSWORD }}" \
             --out "$FINAL_APK"
           echo "✅ Signing and alignment complete: $FINAL_APK"
           echo "final_apk_path=$FINAL_APK" >> $GITHUB_OUTPUT
@@ -85,13 +68,14 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: release-${{ steps.find_app.outputs.app_name }}-${{ github.run_number }}
-          name: "Release ${{ steps.find_app.outputs.app_name }} #${{ github.run_number }}"
+          tag_name: test-release-${{ steps.find_app.outputs.app_name }}-${{ github.run_number }}
+          name: "Test Release ${{ steps.find_app.outputs.app_name }} #${{ github.run_number }} (Debug Signed)"
           body: |
-            🚀 **${{ steps.find_app.outputs.app_name }}**
+            🧪 **${{ steps.find_app.outputs.app_name }} (Debug Build)**
 
             - Recompiled from `decompiled/${{ steps.find_app.outputs.app_name }}/apktool`
-            - Signed and aligned with `uber-apk-signer`.
+            - Signed with a debug key using `uber-apk-signer`.
+            - This is **not** a production release.
             - Workflow run: ${{ github.run_id }}
           files: "${{ steps.sign.outputs.final_apk_path }}"
         env:


### PR DESCRIPTION
This commit updates the release workflow to generate test builds signed with a debug key.

The workflow now uses `uber-apk-signer` without any keystore arguments, which causes it to automatically sign the APK with its built-in debug keystore. All steps related to decoding and managing release keystores have been removed.

This provides a simple and effective way to create test releases for verification without needing access to production signing secrets.