### PR TITLE
feat: Implement APK recompilation and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Recompile, Sign, and Release APK (Test Build)
+name: Recompile, Sign, and Release APK
 
 on:
   workflow_dispatch:
@@ -24,23 +24,10 @@ jobs:
           wget -q https://github.com/iBotPeaches/Apktool/releases/download/v2.9.3/apktool_2.9.3.jar -O apktool.jar
           wget -q https://github.com/patrickfav/uber-apk-signer/releases/download/v1.3.0/uber-apk-signer-1.3.0.jar -O uber-apk-signer.jar
 
-      - name: Find App Name
-        id: find_app
-        run: |
-          APP_DIR=$(find decompiled -mindepth 1 -maxdepth 1 -type d | head -n 1)
-          if [ -z "$APP_DIR" ]; then
-            echo "❌ No app directory found under 'decompiled/'"
-            exit 1
-          fi
-          APP_NAME=$(basename "$APP_DIR")
-          echo "✅ Found app: $APP_NAME"
-          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
-
-      - name: Recompile APK
+      - name: Recompile APK from output/apktool
         id: recompile
         run: |
-          APP_NAME="${{ steps.find_app.outputs.app_name }}"
-          SOURCE_DIR="decompiled/${APP_NAME}/apktool"
+          SOURCE_DIR="output/apktool"
           UNSIGNED_APK="rebuilt_unsigned.apk"
 
           if [ ! -d "$SOURCE_DIR" ]; then
@@ -56,26 +43,25 @@ jobs:
       - name: Sign and Align with Debug Key
         id: sign
         run: |
-          APP_NAME="${{ steps.find_app.outputs.app_name }}"
-          FINAL_APK="${APP_NAME}_debug_release.apk"
+          UNSIGNED_APK="${{ steps.recompile.outputs.unsigned_apk_path }}"
+          SIGNED_APK="rebuilt_signed.apk"
           echo "🔑 Signing and aligning with uber-apk-signer's debug key..."
           java -jar uber-apk-signer.jar \
-            --apks "${{ steps.recompile.outputs.unsigned_apk_path }}" \
-            --out "$FINAL_APK"
-          echo "✅ Signing and alignment complete: $FINAL_APK"
-          echo "final_apk_path=$FINAL_APK" >> $GITHUB_OUTPUT
+            --apks "$UNSIGNED_APK" \
+            --out "$SIGNED_APK"
+          echo "✅ Signing and alignment complete: $SIGNED_APK"
+          echo "final_apk_path=$SIGNED_APK" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: test-release-${{ steps.find_app.outputs.app_name }}-${{ github.run_number }}
-          name: "Test Release ${{ steps.find_app.outputs.app_name }} #${{ github.run_number }} (Debug Signed)"
+          tag_name: release-${{ github.run_number }}
+          name: "Rebuilt APK Release #${{ github.run_number }}"
           body: |
-            🧪 **${{ steps.find_app.outputs.app_name }} (Debug Build)**
+            📦 **Rebuilt APK**
 
-            - Recompiled from `decompiled/${{ steps.find_app.outputs.app_name }}/apktool`
+            - Recompiled from `output/apktool`.
             - Signed with a debug key using `uber-apk-signer`.
-            - This is **not** a production release.
             - Workflow run: ${{ github.run_id }}
           files: "${{ steps.sign.outputs.final_apk_path }}"
         env:


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the process of recompiling, signing, and releasing an APK.

The workflow follows these specific steps:
1.  Recompiles the APK from the `output/apktool` directory using `apktool b`.
2.  Signs and aligns the resulting `rebuilt_unsigned.apk` using `uber-apk-signer`'s built-in debug key, creating `rebuilt_signed.apk`.
3.  Creates a new GitHub Release and uploads the final `rebuilt_signed.apk` as an artifact.

This workflow is triggered manually via `workflow_dispatch`.