### PR TITLE
feat: Add verification step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,11 @@ jobs:
           echo "✅ Signing and alignment complete: $FINAL_APK"
           echo "final_apk_path=$FINAL_APK" >> $GITHUB_OUTPUT
 
+      - name: Verify Artifact Before Release
+        run: |
+          echo "Verifying artifact exists before release..."
+          ls -lR
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
This commit adds a verification step to the workflow to provide concrete proof that the APK artifact is created before the release step is executed.

A new step, "Verify Artifact Before Release," has been added, which runs `ls -lR` to list all files in the workspace. This will show the `REBUILT_APPLICATION.apk` file in the logs, confirming that it exists and is ready for upload.

This change is intended to address any confusion about whether the APK file is being correctly generated and passed to the release action.