### PR TITLE
fix(ci): Make Puter.js workflow robust to malformed JSON

### DIFF
--- a/.github/scripts/sanitize_json.js
+++ b/.github/scripts/sanitize_json.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * This script sanitizes a potentially malformed JSON or JS file to produce a clean JSON array.
+ * It handles two main cases:
+ * 1. Malformed JSON with unescaped newlines within string values (like in Servers.js).
+ * 2. A JSON object that wraps the desired array (e.g., { "Servers": [...] }).
+ *
+ * Usage: node sanitize_json.js <input_path> <output_path>
+ */
+
+const a = () => {
+    const inputPath = process.argv[2];
+    const outputPath = process.argv[3];
+
+    if (!inputPath || !outputPath) {
+        console.error('Usage: node sanitize_json.js <input_path> <output_path>');
+        process.exit(1);
+    }
+
+    console.log(`Sanitizing '${inputPath}' and writing to '${outputPath}'...`);
+
+    try {
+        let content = fs.readFileSync(inputPath, 'utf8');
+
+        // Step 1: Fix unescaped newlines inside JSON strings
+        // This is a common issue in hand-edited config files.
+        let sanitizedContent = '';
+        let inString = false;
+        for (let i = 0; i < content.length; i++) {
+            const char = content[i];
+            // Toggle inString state if we encounter a quote that is not escaped
+            if (char === '"' && (i === 0 || content[i-1] !== '\\')) {
+                inString = !inString;
+            }
+            // If we are inside a string and find a newline, escape it. Otherwise, keep it.
+            if (inString && char === '\n') {
+                sanitizedContent += '\\n';
+            } else {
+                sanitizedContent += char;
+            }
+        }
+
+        // Step 2: Parse the now-valid JSON string
+        const jsonObject = JSON.parse(sanitizedContent);
+
+        // Step 3: Extract the "Servers" array if it exists.
+        // If the root is already an array, use it directly.
+        const serversArray = Array.isArray(jsonObject) ? jsonObject : jsonObject.Servers;
+
+        if (!Array.isArray(serversArray)) {
+            throw new Error('The final processed JSON is not an array and a ".Servers" key was not found.');
+        }
+
+        // Step 4: Write the clean JSON array to the output file.
+        fs.writeFileSync(outputPath, JSON.stringify(serversArray, null, 2));
+
+        console.log('✅ Successfully sanitized and extracted server array.');
+        console.log(`Total servers found: ${serversArray.length}`);
+
+    } catch (error) {
+        console.error('❌ Error during sanitation:', error.message);
+        // Also write the problematic content to the log for debugging
+        console.error('Problematic content received:', fs.readFileSync(inputPath, 'utf8'));
+        process.exit(1);
+    }
+};
+
+a();

--- a/.github/workflows/puter-decrypt.yml
+++ b/.github/workflows/puter-decrypt.yml
@@ -65,53 +65,11 @@ jobs:
           echo "✅ Server file found: $SERVER_FILE_NAME"
           echo "SERVER_FILE_NAME=$SERVER_FILE_NAME" >> $GITHUB_ENV
 
-          # The Servers.js file is malformed JSON (unescaped newlines in strings).
-          # Other files might be a JSON object containing a "Servers" array, or just the array itself.
-          # This step normalizes the input into a clean 'analysis_output/servers.json' which is always an array.
-
-          if [[ "$SERVER_FILE_NAME" == "Servers.js" ]]; then
-            echo "Sanitizing malformed JSON from Servers.js..."
-            # Use a Node.js script to fix unescaped newlines and extract the "Servers" array.
-            cat > sanitize_json.js << 'JS_EOF'
-            const fs = require('fs');
-            const filePath = process.argv[2];
-            const outputPath = process.argv[3];
-            let content = fs.readFileSync(filePath, 'utf8');
-            let sanitizedContent = '';
-            let inString = false;
-            for (let i = 0; i < content.length; i++) {
-                const char = content[i];
-                if (char === '"' && (i === 0 || content[i-1] !== '\\')) {
-                    inString = !inString;
-                }
-                if (inString && char === '\n') {
-                    sanitizedContent += '\\n';
-                } else {
-                    sanitizedContent += char;
-                }
-            }
-            const jsonObject = JSON.parse(sanitizedContent);
-            const serversArray = jsonObject.Servers || jsonObject;
-            fs.writeFileSync(outputPath, JSON.stringify(serversArray, null, 2));
-            JS_EOF
-            node sanitize_json.js "$SERVER_FILE_NAME" analysis_output/servers.json
-          else
-            # Handle servers.json or other well-formed JSON files.
-            # Check if it's an object with a 'Servers' key or just an array.
-            if jq -e '.Servers' "$SERVER_FILE_NAME" > /dev/null 2>&1; then
-               echo "Extracting .Servers array from $SERVER_FILE_NAME..."
-               jq '.Servers' "$SERVER_FILE_NAME" > analysis_output/servers.json
-            else
-               echo "Assuming $SERVER_FILE_NAME is already a JSON array..."
-               jq '.' "$SERVER_FILE_NAME" > analysis_output/servers.json
-            fi
-          fi
+          # Sanitize the found file and extract the server array into a standard location.
+          node .github/scripts/sanitize_json.js "$SERVER_FILE_NAME" "analysis_output/servers.json"
 
           echo "📊 Validating and displaying extracted server data:"
-          if ! jq '.' analysis_output/servers.json; then
-            echo "❌ Failed to produce valid JSON in analysis_output/servers.json"
-            exit 1
-          fi
+          jq '.' analysis_output/servers.json
 
           if [ -f "key_search_report.txt" ]; then
             echo "✅ key_search_report.txt found"


### PR DESCRIPTION
This commit fixes a JSON parsing error in the `puter-decrypt.yml` workflow that occurred when processing `Servers.js`. The previous implementation failed due to shell syntax errors when trying to run a complex script embedded in the YAML.

This commit introduces a cleaner and more robust solution by separating the logic from the configuration:

1.  **Adds a dedicated sanitization script:** A new Node.js script, `.github/scripts/sanitize_json.js`, is created. This script is responsible for:
    - Reading potentially malformed JSON files (like `Servers.js`).
    - Fixing unescaped newline characters within string values.
    - Parsing the sanitized content.
    - Extracting the server list, whether it's the root object or nested under a "Servers" key.
    - Writing a clean, valid JSON array to an output file.

2.  **Simplifies the workflow:** The `puter-decrypt.yml` workflow is updated to simply call this external script. This removes the complex, error-prone multi-line shell command from the YAML, making the workflow much easier to read, maintain, and debug.