### PR TITLE
Fix: Correctly parse Jules API session ID

### DIFF
--- a/decode-apk-automation/src/jules-api-client.js
+++ b/decode-apk-automation/src/jules-api-client.js
@@ -86,11 +86,7 @@ class JulesAPIClient {
 
       const response = await this.client.post('/sessions', payload);
 
-      console.log('Session created:', {
-        sessionId: response.data.id,
-        name: response.data.name,
-        title: response.data.title
-      });
+      console.log('Session created:', response.data);
 
       return response.data;
     } catch (error) {

--- a/decode-apk-automation/src/main-workflow.js
+++ b/decode-apk-automation/src/main-workflow.js
@@ -54,19 +54,22 @@ async function runDecryptionWorkflow() {
       false // Auto-approve plan
     );
 
-    console.log(`\n=== Step 4: Monitoring Session ${session.id} ===`);
-    const result = await julesClient.monitorSession(session.id, 20000, 1800000); // 30 min timeout
+    // Extract the session ID from the 'name' field (e.g., "sessions/12345")
+    const sessionId = session.name.split('/').pop();
+
+    console.log(`\n=== Step 4: Monitoring Session ${sessionId} ===`);
+    const result = await julesClient.monitorSession(sessionId, 20000, 1800000); // 30 min timeout
 
     if (result.status === 'completed') {
       console.log('\n=== Step 5: Session Completed. Processing Final Report... ===');
-      const activities = await julesClient.getAllActivities(session.id);
+      const activities = await julesClient.getAllActivities(sessionId);
       const decryptedData = processActivityResult(activities);
 
       console.log('✅ Workflow completed successfully!');
       return { success: true, decryptedData: decryptedData };
     } else {
-      console.error(`❌ Session ${session.id} failed or timed out.`);
-      await errorHandler.handleError(session.id, 'DECRYPTION_FAILED', result.error || 'Timeout');
+      console.error(`❌ Session ${sessionId} failed or timed out.`);
+      await errorHandler.handleError(sessionId, 'DECRYPTION_FAILED', result.error || 'Timeout');
 
       return {
         success: false,


### PR DESCRIPTION
Resolves a '404 Not Found' error that occurred when monitoring a Jules session. The issue was caused by an attempt to access a non-existent `id` field from the session creation response.

This change modifies the workflow to correctly parse the session ID from the `name` field (e.g., 'sessions/12345'), which is the standard format for this API. Additionally, logging for the session creation response has been enhanced to provide more context for future debugging.